### PR TITLE
fix: character-list-generation APIのYAMLパースエラー修正

### DIFF
--- a/apps/proxy-server/src/services/aiIntegration.ts
+++ b/apps/proxy-server/src/services/aiIntegration.ts
@@ -26,7 +26,7 @@ import {
 } from '../utils/aiErrorHandler.js';
 import templateManager from '../utils/aiTemplateManager.js';
 import { WORLD_BUILDER } from '../utils/systemPrompts.js';
-import { parseYamlSafely } from '../utils/securityUtils.js';
+import { parseYamlSafely, parseJsonSafely } from '../utils/securityUtils.js';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
 // サポートされているモデル設定
@@ -266,7 +266,7 @@ async function callOpenAI(
   let parsedContent;
   if (responseFormat === 'json') {
     try {
-      parsedContent = JSON.parse(responseText);
+      parsedContent = parseJsonSafely(responseText);
     } catch {
       parsedContent = handleAIResponseParsing(responseText, true, 'json');
     }
@@ -338,7 +338,7 @@ async function callAnthropic(
   let parsedContent;
   if (responseFormat === 'json') {
     try {
-      parsedContent = JSON.parse(dummyResponse);
+      parsedContent = parseJsonSafely(dummyResponse);
     } catch {
       parsedContent = handleAIResponseParsing(dummyResponse, true, 'json');
     }
@@ -618,7 +618,7 @@ ${request.userPrompt}`;
           ? match[1] || match[2] || responseText
           : responseText;
 
-        parsedContent = JSON.parse(jsonStr.trim());
+        parsedContent = parseJsonSafely(jsonStr.trim());
         console.log(`[AI] JSON解析成功: ${typeof parsedContent}, ${jsonStr}`);
       } catch (parseError) {
         console.error(`[AI] JSONパースエラー:`, parseError);

--- a/apps/proxy-server/test-yaml-parse.js
+++ b/apps/proxy-server/test-yaml-parse.js
@@ -1,0 +1,75 @@
+// テストスクリプト: コードブロック記法の処理をテスト
+import { parseYamlSafely, parseJsonSafely } from './dist/utils/securityUtils.js';
+
+console.log('===== YAMLパーステスト =====');
+
+// テストケース1: コードブロック記法付きYAML
+const yamlWithCodeBlock = `\`\`\`yaml
+---
+- name: "オトハ・クロエ"
+  role: "protagonist"
+  importance: "主要"
+  description: "過労死し、スキルなしで異世界に転生した元会社員。"
+- name: "サイラス・アーレン"
+  role: "supporting"
+  importance: "主要"
+  description: "王国の辺境を守る無口で実直な騎士。"
+\`\`\``;
+
+try {
+  const parsed1 = parseYamlSafely(yamlWithCodeBlock);
+  console.log('✓ テスト1成功: コードブロック記法付きYAML');
+  console.log('  パース結果:', JSON.stringify(parsed1, null, 2));
+} catch (error) {
+  console.error('✗ テスト1失敗:', error.message);
+}
+
+// テストケース2: 通常のYAML（コードブロックなし）
+const normalYaml = `---
+- name: "テストキャラ1"
+  role: "protagonist"
+- name: "テストキャラ2"
+  role: "antagonist"`;
+
+try {
+  const parsed2 = parseYamlSafely(normalYaml);
+  console.log('✓ テスト2成功: 通常のYAML');
+  console.log('  パース結果:', JSON.stringify(parsed2, null, 2));
+} catch (error) {
+  console.error('✗ テスト2失敗:', error.message);
+}
+
+console.log('\n===== JSONパーステスト =====');
+
+// テストケース3: コードブロック記法付きJSON
+const jsonWithCodeBlock = `\`\`\`json
+{
+  "characters": [
+    {
+      "name": "主人公",
+      "role": "protagonist"
+    }
+  ]
+}
+\`\`\``;
+
+try {
+  const parsed3 = parseJsonSafely(jsonWithCodeBlock);
+  console.log('✓ テスト3成功: コードブロック記法付きJSON');
+  console.log('  パース結果:', JSON.stringify(parsed3, null, 2));
+} catch (error) {
+  console.error('✗ テスト3失敗:', error.message);
+}
+
+// テストケース4: 通常のJSON
+const normalJson = `{"name": "テスト", "value": 123}`;
+
+try {
+  const parsed4 = parseJsonSafely(normalJson);
+  console.log('✓ テスト4成功: 通常のJSON');
+  console.log('  パース結果:', JSON.stringify(parsed4, null, 2));
+} catch (error) {
+  console.error('✗ テスト4失敗:', error.message);
+}
+
+console.log('\n===== すべてのテスト完了 =====');


### PR DESCRIPTION
## 問題

character-list-generation APIでYAMLパースエラーが発生していました。原因はGeminiなどのAIモデルがYAMLレスポンスをマークダウンのコードブロック形式（```yaml...```）で返すためでした。

## 修正内容

### 🔧 コードブロック形式の対応
- **removeCodeBlockFormatting()関数**: YAMLのマークダウンコードブロック記法（```yaml...```）を除去
- **removeJsonCodeBlockFormatting()関数**: JSONのマークダウンコードブロック記法（```json...```）を除去
- GeminiやClaude等のAIモデルが返すレスポンス形式に対応

### 🛡️ セキュリティ強化
- **parseJsonSafely()関数**: JSON.parse()をセキュアなパースに置換
- **sanitizeUserInput()関数の改善**: YAML構造に必要な改行・タブ・CRを保持しつつ危険な制御文字は除去

### ✅ テスト追加
- **test-yaml-parse.js**: コードブロック形式と通常形式の両方のテストケースを追加
- YAML/JSON パースの全パターンを検証

## テスト結果

```
===== YAMLパーステスト =====
✓ テスト1成功: コードブロック記法付きYAML
✓ テスト2成功: 通常のYAML

===== JSONパーステスト =====
✓ テスト3成功: コードブロック記法付きJSON
✓ テスト4成功: 通常のJSON
```

## 影響範囲

- `apps/proxy-server/src/utils/securityUtils.ts`: セキュリティユーティリティの拡張
- `apps/proxy-server/src/services/aiIntegration.ts`: JSONパースをセキュアに変更
- character-list-generation APIの安定性向上

🤖 Generated with [Claude Code](https://claude.ai/code)