### PR TITLE
fix: プロット生成のトークン制限を増加

### DIFF
--- a/apps/proxy-server/src/routes/aiAgent.ts
+++ b/apps/proxy-server/src/routes/aiAgent.ts
@@ -533,7 +533,7 @@ router.post('/plot-development', async (req, res) => {
       userPrompt: contextualPrompt,
       options: {
         temperature: 0.7,
-        maxTokens: 2000,
+        maxTokens: 6000, // 起承転結+導入部分（4~5個のプロットアイテム）に十分なトークン数
         expectedFormat: 'text',
         responseFormat: 'text',
       },


### PR DESCRIPTION
## 問題

プロット生成APIで3つ目のプロットアイテムの途中で生成が終わってしまう問題がありました。起承転結を意識した物語構成には、起承転結+導入部分で4~5個のプロットアイテムが必要です。

## 修正内容

### 📝 maxTokens制限の増加
- `/api/agent/plot-development` エンドポイントのmaxTokensを**2000から6000**に増加
- 4~5個のプロットアイテムを完全に生成できるように対応

## 影響範囲

- `apps/proxy-server/src/routes/aiAgent.ts`: プロット生成エンドポイントのトークン制限変更
- より詳細で完全なプロット生成が可能に
- 起承転結を含む物語構成の改善

## テスト確認項目

- [ ] プロット生成で4~5個のアイテムが完全に生成されること
- [ ] 各プロットアイテムが途中で切れないこと
- [ ] 起承転結の構成が適切に生成されること

🤖 Generated with [Claude Code](https://claude.ai/code)